### PR TITLE
Include top of the stacktrace in error embed for emblem command

### DIFF
--- a/Felicity/DiscordCommands/Interactions/EmblemCommands.cs
+++ b/Felicity/DiscordCommands/Interactions/EmblemCommands.cs
@@ -297,6 +297,9 @@ public class EmblemCommands : InteractionModuleBase<ShardedInteractionContext>
         {
             var errorEmbed = Embeds.MakeErrorEmbed();
             errorEmbed.Description = error.Message;
+            if (error.StackTrace != null) {
+                errorEmbed.Description += "\n" + error.StackTrace.Split(Environment.NewLine).FirstOrDefault();
+            }
             await FollowupAsync(embed: errorEmbed.Build());
             return;
         }


### PR DESCRIPTION
This is the only place that the exception is directly logged to clients with the intent for them to open an issue on GitHub, so may as well give them more information to submit.

The alternative to this would be:
Generate a GUID for the exception.
Log the exception + GUID.
Display the GUID to client in the ErrorEmbed, for them to log an issue on Discord/GitHub.

I do not know if the stack trace will contain any sensitive info from the bot host, hence the alternative proposal.